### PR TITLE
fix(home): preserve MiXiT case on "Spirit" section title

### DIFF
--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -37,7 +37,7 @@ home.speakers.piezzardi=Entrepreneur
 home.speakers.nitot=Standards, Mozilla, Cozy
 home.speakers.tba=Speakers 2017 to be announced
 home.speakers.submit=Submit a talk
-home.spirit.title=MiXiT spirit
+home.spirit.title=<span class="no-caps">MiXiT</span> spirit
 home.spirit.cityhall.title=An evening in Lyon City Hall
 home.spirit.cityhall.description=Once again, we are be lucky enough to host our party in the prestigious Lyon City Hall.
 home.spirit.pancakes.title=Homemade crêpes

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -37,7 +37,7 @@ home.speakers.piezzardi=Entrepreneur
 home.speakers.nitot=Standards, Mozilla, Cozy
 home.speakers.tba=Speakers 2017 à venir
 home.speakers.submit=Proposer un sujet
-home.spirit.title=L'esprit MiXiT
+home.spirit.title=L'esprit <span class="no-caps">MiXiT</span>
 home.spirit.cityhall.title=Une soirée à l'Hôtel de ville
 home.spirit.cityhall.description=Nous aurons encore une fois la chance de bénéficier du cadre prestigieux de l’hôtel de ville pour notre soirée participants.
 home.spirit.pancakes.title=Des crêpes maison

--- a/src/main/sass/app.scss
+++ b/src/main/sass/app.scss
@@ -91,4 +91,8 @@ small {
 	@include breakpoint(medium) {
 		font-size: 50%;
 	}
+
+	.no-caps {
+		text-transform: none;
+	}
 }


### PR DESCRIPTION
This PR is for @doublejess.
It preserves the case for "MiXiT" in "Spirit" section on home page.

BEFORE:
![image](https://cloud.githubusercontent.com/assets/750715/22763121/231d3096-ee63-11e6-8d9b-5a6a0ea1f978.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/750715/22763129/2dc91ad2-ee63-11e6-8d27-c69be74ccca8.png)

I know nothing about SASS, BEM, and CSS, so this might not be the right way to do this.