### PR TITLE
fix(staff): member name as <h3>

### DIFF
--- a/src/main/resources/templates/staff.mustache
+++ b/src/main/resources/templates/staff.mustache
@@ -21,7 +21,7 @@
                 <img src="https://www.gravatar.com/avatar/{{logoUrl}}" class="mxt-img--team"/>
             </div>
             <div class="small-12 medium-8 columns">
-                {{firstname}} {{lastname}}<br/>
+                <h3>{{firstname}} {{lastname}}</h3>
                 {{shortDescription}}
                 <ul class="menu simple">
                 {{#links}}


### PR DESCRIPTION
The member name used to be not styled. It is now defined as `<h3>`, which is semantically what should follow the existing `<h1>` and `<h2`.

BEFORE:
![image](https://cloud.githubusercontent.com/assets/750715/22956578/387882d2-f323-11e6-9dcf-5412810f6fa8.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/750715/22956567/295949e4-f323-11e6-9bd9-984ccfc3bbb7.png)
