### PR TITLE
feat(routes): expose legacy urls seen in old blog posts

### DIFF
--- a/src/main/kotlin/mixit/controller/ArticleController.kt
+++ b/src/main/kotlin/mixit/controller/ArticleController.kt
@@ -7,12 +7,11 @@ import mixit.repository.ArticleRepository
 import mixit.support.LazyRouterFunction
 import mixit.support.MarkdownConverter
 import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType.*
-import org.springframework.web.reactive.function.fromPublisher
-import org.springframework.web.reactive.function.server.*
-import org.springframework.web.reactive.function.server.RequestPredicates.*
-import org.springframework.web.reactive.function.server.ServerResponse.ok
+import org.springframework.http.MediaType.APPLICATION_JSON_UTF8
 import org.springframework.stereotype.Controller
+import org.springframework.web.reactive.function.fromPublisher
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse.ok
 import java.time.format.DateTimeFormatter
 
 
@@ -27,7 +26,7 @@ class ArticleController(val repository: ArticleRepository, val markdownConverter
         accept(TEXT_HTML).apply {
             // /articles/** are old routes used by the previous version of our website
             (GET("/blog/") or GET("/articles/")) { findAllView(it) }
-            (GET("/blog/{id}") or GET("/article/{id}")) { findOneView(it) }
+            (GET("/blog/{id}") or GET("/article/{id}") or GET("/article/{id}/")) { findOneView(it) }
         }
         accept(APPLICATION_JSON).apply {
             GET("/api/blog/", this@ArticleController::findAll)

--- a/src/main/kotlin/mixit/controller/SessionController.kt
+++ b/src/main/kotlin/mixit/controller/SessionController.kt
@@ -5,11 +5,10 @@ import mixit.repository.EventRepository
 import mixit.repository.SessionRepository
 import mixit.support.LazyRouterFunction
 import mixit.support.MarkdownConverter
-import org.springframework.http.MediaType.*
+import org.springframework.http.MediaType.APPLICATION_JSON_UTF8
 import org.springframework.stereotype.Controller
 import org.springframework.web.reactive.function.fromPublisher
-import org.springframework.web.reactive.function.server.*
-import org.springframework.web.reactive.function.server.RequestPredicates.*
+import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse.ok
 import java.time.LocalDateTime
 
@@ -21,9 +20,9 @@ class SessionController(val repository: SessionRepository, val eventRepository: 
     // TODO Remove this@ArticleController when KT-15667 will be fixed
     override val routes: Routes.() -> Unit = {
         accept(TEXT_HTML).apply {
-            GET("/sessions/", this@SessionController::findAllView)
+            (GET("/sessions/") or GET("/sessions/")) { findAllView(it) }
             GET("/{year}/sessions/", this@SessionController::findByEventView)
-            (GET("/session/{id}") or GET("/session/{id}/")) { findOneView(it) }
+            (GET("/session/{id}") or GET("/session/{id}/") or GET("/session/{id}/{sluggifiedTitle}/")) { findOneView(it) }
         }
         accept(APPLICATION_JSON).apply {
             GET("/api/session/{login}", this@SessionController::findOne)

--- a/src/main/kotlin/mixit/controller/UserController.kt
+++ b/src/main/kotlin/mixit/controller/UserController.kt
@@ -5,15 +5,14 @@ import mixit.model.User
 import mixit.repository.UserRepository
 import mixit.support.LazyRouterFunction
 import mixit.support.MarkdownConverter
-import org.springframework.http.MediaType.*
+import org.springframework.http.MediaType.APPLICATION_JSON_UTF8
 import org.springframework.stereotype.Controller
 import org.springframework.web.reactive.function.BodyInserters.fromObject
 import org.springframework.web.reactive.function.fromPublisher
-import org.springframework.web.reactive.function.server.*
-import org.springframework.web.reactive.function.server.RequestPredicates.GET
-import org.springframework.web.reactive.function.server.RequestPredicates.accept
+import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse.created
 import org.springframework.web.reactive.function.server.ServerResponse.ok
+import org.springframework.web.reactive.function.server.bodyToMono
 import java.net.URI
 import java.net.URLDecoder
 import java.util.*
@@ -26,8 +25,8 @@ class UserController(val repository: UserRepository, val markdownConverter: Mark
     override val routes: Routes.() -> Unit = {
         accept(TEXT_HTML).apply {
             (GET("/user/") or GET("/users/")) { findAllView() }
-            (GET("/user/{login}") or GET("/speaker/{login}") or GET("/member/{login}") or GET("/sponsor/{login}")) { findOneView(it) }
-            GET("/about/", this@UserController::findAboutView)
+            (GET("/user/{login}") or GET("/speaker/{login}") or GET("/member/{login}") or GET("/member/member/{login}") or GET("/sponsor/{login}") or GET("/member/sponsor/{login}")) { findOneView(it) }
+            (GET("/about/") or GET("/about")) { findAboutView() }
         }
         accept(APPLICATION_JSON).apply {
             GET("/api/user/", this@UserController::findAll)
@@ -104,7 +103,7 @@ class UserController(val repository: UserRepository, val markdownConverter: Mark
                 .body(fromObject(u))
             }
 
-    fun findAboutView(req: ServerRequest) = repository.findByRole(Role.STAFF)
+    fun findAboutView() = repository.findByRole(Role.STAFF)
             .collectList()
             .then { u ->
                 val users = u.map { prepareForHtmlDisplay(it) }


### PR DESCRIPTION
Add all mising legacy urls seens in old blog posts (at least the 30 latest ones).
All seen routes have been added, unless:

Les articles qui font référence à l’ancien site web, et dont les URLs sont fondamentalement obsolètes :
- http://localhost:8080/blog/282 :
- http://localhost:8080/blog/242

Les fonctionnalités manquantes dans le site :
- http://localhost:8080/blog/131
    - http://localhost:8080/infos/acces
    - http://localhost:8080/mixit15/planning (planning d’un event)
- http://localhost:8080/blog/91
    - http://localhost:8080/profile/mojavelinux (user/speaker par son username)
- http://localhost:8080/blog/77
    - http://localhost:8080/mixit15/sponsors (liste des sponsors d’un event)
