### PR TITLE
Sponsors are shuffled at request time, on home and sponsors page

### DIFF
--- a/src/main/kotlin/mixit/controller/GlobalController.kt
+++ b/src/main/kotlin/mixit/controller/GlobalController.kt
@@ -25,15 +25,15 @@ class GlobalController(val repository: EventRepository) : LazyRouterFunction() {
         resources("/**", ClassPathResource("static/"))
     }
 
-    fun homeView(req: ServerRequest) = repository.findOne("mixit17")
+    fun homeView(req: ServerRequest) = repository.findOne("mixit17")    // TODO This could benefit from an in-memory cache with like 1H retention (data never change)
             .then { events ->
                 val sponsors = events.sponsors.groupBy { it.level }
                 ok().render("home", mapOf(
-                        Pair("sponsors-gold", sponsors[GOLD]!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
-                        Pair("sponsors-silver", sponsors[SILVER]!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
-                        Pair("sponsors-hosting", sponsors[HOSTING]!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
-                        Pair("sponsors-lanyard", sponsors[LANYARD]!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
-                        Pair("sponsors-party", sponsors[PARTY]!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) })
+                        Pair("sponsors-gold", EventSponsoring.shuffle(sponsors[GOLD])!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
+                        Pair("sponsors-silver", EventSponsoring.shuffle(sponsors[SILVER])!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
+                        Pair("sponsors-hosting", EventSponsoring.shuffle(sponsors[HOSTING])!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
+                        Pair("sponsors-lanyard", EventSponsoring.shuffle(sponsors[LANYARD])!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) }),
+                        Pair("sponsors-party", EventSponsoring.shuffle(sponsors[PARTY])!!.map { eventSponsoring -> SponsorDto.toDto(eventSponsoring) })
                 ))
             }
 

--- a/src/main/kotlin/mixit/controller/SponsorController.kt
+++ b/src/main/kotlin/mixit/controller/SponsorController.kt
@@ -1,5 +1,6 @@
 package mixit.controller
 
+import mixit.model.EventSponsoring
 import mixit.model.SponsorshipLevel.*
 import mixit.repository.EventRepository
 import mixit.repository.UserRepository
@@ -22,15 +23,15 @@ class SponsorController(val eventRepository: EventRepository, val userRepository
         }
     }
 
-    fun findAllView(req: ServerRequest) = eventRepository.findOne("mixit17").then { events ->
+    fun findAllView(req: ServerRequest) = eventRepository.findOne("mixit17").then { events ->   // TODO This could benefit from an in-memory cache with like 1H retention (data never change)
         val sponsors = events.sponsors.groupBy { it.level }
 
         ok().render("sponsors", mapOf(
-            Pair("sponsors-gold", sponsors[GOLD]),
-            Pair("sponsors-silver", sponsors[SILVER]),
-            Pair("sponsors-hosting", sponsors[HOSTING]),
-            Pair("sponsors-lanyard", sponsors[LANYARD]),
-            Pair("sponsors-party", sponsors[PARTY])
+            Pair("sponsors-gold", EventSponsoring.shuffle(sponsors[GOLD])),
+            Pair("sponsors-silver", EventSponsoring.shuffle(sponsors[SILVER])),
+            Pair("sponsors-hosting", EventSponsoring.shuffle(sponsors[HOSTING])),
+            Pair("sponsors-lanyard", EventSponsoring.shuffle(sponsors[LANYARD])),
+            Pair("sponsors-party", EventSponsoring.shuffle(sponsors[PARTY]))
         ))
     }
 

--- a/src/main/kotlin/mixit/model/Event.kt
+++ b/src/main/kotlin/mixit/model/Event.kt
@@ -3,6 +3,7 @@ package mixit.model
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDate
+import java.util.*
 
 @Document
 data class Event(
@@ -20,7 +21,17 @@ data class EventSponsoring(
         val level: SponsorshipLevel,
         val sponsor: User,
         val subscriptionDate: LocalDate = LocalDate.now()
-)
+) {
+
+    companion object {
+        fun shuffle(sponsors: Iterable<EventSponsoring>?): Iterable<EventSponsoring>? {
+            if (sponsors == null) return null;
+            val shuffledSponsors: MutableList<EventSponsoring> = sponsors.toMutableList();
+            Collections.shuffle(shuffledSponsors);
+            return shuffledSponsors.asIterable();
+        }
+    }
+}
 
 enum class SponsorshipLevel {
     GOLD,


### PR DESCRIPTION
Fix #90

In case the previous sponsors consistent order was not really wanted, it's better for fairness to have them shuffled at request time.