### PR TITLE
fix(navbar): preserve "MiXiT" case in archives entries

### DIFF
--- a/src/main/resources/templates/header.mustache
+++ b/src/main/resources/templates/header.mustache
@@ -38,11 +38,11 @@
             <li>
                 <a href="#" class="mxt-menu__item--nav">{{#i18n}}header.menu.archives{{/i18n}}</a>
                 <ul class="menu">
-                    <li><a href="{{localePrefix}}/2016/sessions/" class="mxt-menu__item--nav">MiXiT 2016</a></li>
-                    <li><a href="{{localePrefix}}/2015/sessions/" class="mxt-menu__item--nav">MiXiT 2015</a></li>
-                    <li><a href="{{localePrefix}}/2014/sessions/" class="mxt-menu__item--nav">MiXiT 2014</a></li>
-                    <li><a href="{{localePrefix}}/2013/sessions/" class="mxt-menu__item--nav">MiXiT 2013</a></li>
-                    <li><a href="{{localePrefix}}/2012/sessions/" class="mxt-menu__item--nav">MiXiT 2012</a></li>
+                    <li><a href="{{localePrefix}}/2016/sessions/" class="mxt-menu__item--nav"><span class="no-caps">MiXiT</span> 2016</a></li>
+                    <li><a href="{{localePrefix}}/2015/sessions/" class="mxt-menu__item--nav"><span class="no-caps">MiXiT</span> 2015</a></li>
+                    <li><a href="{{localePrefix}}/2014/sessions/" class="mxt-menu__item--nav"><span class="no-caps">MiXiT</span> 2014</a></li>
+                    <li><a href="{{localePrefix}}/2013/sessions/" class="mxt-menu__item--nav"><span class="no-caps">MiXiT</span> 2013</a></li>
+                    <li><a href="{{localePrefix}}/2012/sessions/" class="mxt-menu__item--nav"><span class="no-caps">MiXiT</span> 2012</a></li>
                 </ul>
             </li>
             <li><a href="{{localePrefix}}/sponsors/" class="mxt-menu__item--nav">{{#i18n}}header.menu.sponsors{{/i18n}}</a></li>

--- a/src/main/sass/app.scss
+++ b/src/main/sass/app.scss
@@ -91,8 +91,8 @@ small {
 	@include breakpoint(medium) {
 		font-size: 50%;
 	}
+}
 
-	.no-caps {
-		text-transform: none;
-	}
+.no-caps {
+	text-transform: none;
 }


### PR DESCRIPTION
In navbar, Archives dropdown: instead of showing `MIXIT 2016`, entries now show `MiXiT 2016`.